### PR TITLE
fix(md-3906): prevent supernova from remounting the table

### DIFF
--- a/src/components/Supernova.tsx
+++ b/src/components/Supernova.tsx
@@ -73,6 +73,7 @@ const Supernova: React.FC<SupernovaProps> = ({
   const resetSelectionsConfig = useResetAtom(supernovaStateAtom);
   const [componentData, setComponentData] = useState(undefined);
   const containerRef = useRef<any>(undefined);
+  const elementRef = useRef<Element>(undefined);
   const bodyRef = useRef<any>(undefined);
   const titleLayout = useRef(undefined);
   const mounted = useRef(true);
@@ -132,7 +133,10 @@ const Supernova: React.FC<SupernovaProps> = ({
 
   const onCanvas = useCallback(
     async (canvas: any) => {
-      const element = new Element(canvas);
+      if(!elementRef.current) {
+        elementRef.current = new Element(canvas);
+      }
+      const element = elementRef.current;
 
       element.setLongPressHandler(onLongPress);
 


### PR DESCRIPTION
This seems to be an issue in NebulaEngine, something to do with Canvas and Android. 

Issue:
On the initial render NebulaEngine.getJsxComponent returns a valid component. However, when closing the expand view Supernova will re-render calling renderJsxComponent, in which the call to NebulaEngine.getJsxComponent returns undefined. That then causes the jsx component to unmount, and then eventually NebulaEngine.getJsxComponent returns valid component again.

Fix:
Cache the previous component, and re-use it if NebulaEngine.getJsxComponent returns undefined. Once NebulaEngine.getJsxComponent returns a valid component, we will use that as the new jsx component.
